### PR TITLE
Localization simplification

### DIFF
--- a/Fronter/Configuration/fronter-example-configuration-ck2.txt
+++ b/Fronter/Configuration/fronter-example-configuration-ck2.txt
@@ -1,60 +1,45 @@
-﻿supportedLocLanguages = { english french } # Keep this line at the top.
-
-name = CK2ToEU4
+﻿name = CK2ToEU4
 converterFolder = CK2ToEU4
-displayName_english = "Crusader Kings II To Europa Universalis IV"
-displayName_french = "Crusader Kings II à Europa Universalis IV"
-sourceGame_english = "Crusader Kings II"
-sourceGame_french = "Crusader Kings II"
-targetGame_english = "Europa Universalis IV"
-targetGame_french = "Europa Universalis IV"
+displayName = DISPLAYNAME
+sourceGame = SOURCEGAME
+targetGame = TARGETGAME
 
 requiredFolder = {
 	name = CK2directory
-	displayName_english = "Crusader Kings II Install directory"
-	displayName_french = "Répertoire d'installation de Crusader Kings II"
-	tooltip_english = "A path on your computer where Crusader Kings 2 is installed"
-	tooltip_french = "Un chemin sur votre ordinateur où Crusader Kings 2 est installé"
+	displayName = FOLDER1
+	tooltip = FOLDER1TIP
 	mandatory = true
 	searchPathType = steamFolder
 	searchPathID = 203770
 }
 requiredFolder = {
 	name = CK2ModsDirectory
-	displayName_english = "Crusader Kings II Mods Directory"
-	displayName_french = "Répertoire des mods de Crusader Kings II"
-	tooltip_english = "A path on your computer where Crusader Kings II keeps mods"
-	tooltip_french = "Un chemin sur votre ordinateur où Crusader Kings II conserve les mods"
+	displayName = FOLDER2
+	tooltip = FOLDER2TIP
 	mandatory = true
 	searchPathType = windowsUsersFolder
 	searchPath = "Paradox Interactive\Crusader Kings II\mod"
 }
 requiredFolder = {
 	name = EU4directory
-	displayName_english = "Europa Universalis IV Install directory"
-	displayName_french = "Répertoire d'installation d'Europa Universalis IV"
-	tooltip_english = "A path on your computer where Europa Universalis IV is installed"
-	tooltip_french = "Un chemin sur votre ordinateur où Europa Universalis IV est installé"
+	displayName = FOLDER3
+	tooltip = FOLDER3TIP
 	mandatory = true
 	searchPathType = steamFolder
 	searchPathID = 236850
 }
 requiredFolder = {
 	name = targetGameModPath
-	displayName_english = "Europa Universalis IV Mods directory"
-	displayName_french = "Répertoire des Mods Europa Universalis IV"
-	tooltip_english = "A path on your computer where Europa Universalis IV keeps mods"
-	tooltip_french = "Un chemin sur votre ordinateur où Europa Universalis IV conserve les mods"
+	displayName = FOLDER4
+	tooltip = FOLDER4TIP
 	mandatory = true
 	searchPathType = windowsUsersFolder
 	searchPath = "Paradox Interactive\Europa Universalis IV\mod"
 }
 requiredFile = {
 	name = converterExe
-	displayName_english = "Path to the converter executable"
-	displayName_french = "Chemin vers l'exécutable du convertisseur"
-	tooltip_english = "Path to CK2ToEU4Converter.exe"
-	tooltip_french = "Chemin d'accès à CK2ToEU4Converter.exe"
+	displayName = FILE1
+	tooltip = FILE1TIP
 	mandatory = true
 	outputtable = false
 	searchPathType = converterFolder
@@ -64,10 +49,8 @@ requiredFile = {
 }
 requiredFile = {
 	name = SaveGame
-	displayName_english = "Path to the CK2 Savegame"
-	displayName_french = "Chemin vers le jeu de sauvegarde CK2"
-	tooltip_english = "Path to your savegame from CK2"
-	tooltip_french = "Chemin vers votre sauvegarde depuis CK2"
+	displayName = FILE2
+	tooltip = FILE2TIP
 	mandatory = true
 	outputtable = true
 	searchPathType = windowsUsersFolder

--- a/Fronter/Configuration/fronter-example-options-ck2.txt
+++ b/Fronter/Configuration/fronter-example-options-ck2.txt
@@ -1,228 +1,173 @@
 option = {
 	name = i_am_hre
-	displayName_english = "Which empire inherits EU4 HRE mechanics and shatters?"
-	displayName_french = "Quel empire hérite de la mécanique EU4 HRE et se brise?"
-	tooltip_english = "Only one empire can use HRE mechanics."
-	tooltip_french = "Un seul empire peut utiliser la mécanique HRE."
+	displayName = OPTION1
+	tooltip = OPTION1TIP
 	radioSelector = {
 		radioOption = {
 			name = 1
-			displayName_english = "The HRE [obviously]"
-			displayName_french = "L'HRE [évidemment]"
-			tooltip_english = "e_hre"
-			tooltip_french = "e_hre"
+			displayName = OP1R1
+			tooltip = OP1R1TIP
 			default = true
 		}
 		radioOption = {
 			name = 2
-			displayName_english = "Byzantium! [Holy and Roman and Empire]"
-			displayName_french = "Byzance! [Saint et Romain et Empire]"
-			tooltip_english = "e_byzantium"
-			tooltip_french = "e_byzantium"
+			displayName = OP1R2
+			tooltip = OP1R2TIP
 			default = false
 		}
 		radioOption = {
 			name = 3
-			displayName_english = "Uh, Rome?"
-			displayName_french = "Euh, Rome?"
-			tooltip_english = "e_roman_empire"
-			tooltip_french = "e_roman_empire"
+			displayName = OP1R3
+			tooltip = OP1R3TIP
 			default = false		
 		}
 		radioOption = {
 			name = 4
-			displayName_english = "Defined in i_am_hre.txt"
-			displayName_french = "Défini dans i_am_hre.txt"
-			tooltip_english = "As defined manually."
-			tooltip_french = "Comme défini manuellement."
+			displayName = OP1R4
+			tooltip = OP1R4TIP
 			default = false
 		}
 		radioOption = {		
 			name = 5
-			displayName_english = "None [no HRE shattering]"
-			displayName_french = "Aucun [aucun HRE brisant]"
-			tooltip_english = "Dropped."
-			tooltip_french = "Chuté."
+			displayName = OP1R5
+			tooltip = OP1R5TIP
 			default = false
 		}
 	}
 }
 option = {
 	name = shatter_hre_level
-	displayName_english = "If we're shattering HRE, how far down do we go?"
-	displayName_french = "Si nous brisons l'EDH, jusqu'où allons-nous?"
-	tooltip_english = "HRE should be shattered to duchies as it increases prince number and thus stability."
-	tooltip_french = "L'EDH devrait être brisée en duchés car elle augmente le nombre de prince et donc la stabilité."
+	displayName = OPTION2
+	tooltip = OPTION2TIP
 	radioSelector = {
 		radioOption = {
 			name = 1
-			displayName_english = "Down to duchies [default]"
-			displayName_french = "Jusqu'aux duchés [par défaut]"
-			tooltip_english = "Need Duchies for stability."
-			tooltip_french = "Besoin de duchés pour la stabilité."
+			displayName = OP2R1
+			tooltip = OP2R1TIP
 			default = true
 		}
 		radioOption = {
 			name = 2
-			displayName_english = "Keep kingdoms if any [not recommended]"
-			displayName_french = "Gardez les royaumes le cas échéant [non recommandé]"
-			tooltip_english = "Kingdoms remain."
-			tooltip_french = "Les royaumes restent."
+			displayName = OP2R2
+			tooltip = OP2R2TIP
 			default = false
 		}
 	}
 }
 option = {
 	name = shatter_empires
-	displayName_english = "Should we shatter other empires?"
-	displayName_french = "Faut-il briser d'autres empires?"
-	tooltip_english = "Makes the game more dynamic. New countries won't be united."
-	tooltip_french = "Rend le jeu plus dynamique. De nouveaux pays ne seront pas unis."
+	displayName = OPTION3
+	tooltip = OPTION3TIP
 	radioSelector = {
 		radioOption = {
 			name = 1
-			displayName_english = "No, as they were [default]"
-			displayName_french = "Non, comme ils l'étaient [par défaut]"
-			tooltip_english = "Uses CK2 states."
-			tooltip_french = "Utilise les états CK2."
+			displayName = OP3R1
+			tooltip = OP3R1TIP
 			default = true
 		}
 		radioOption = {
 			name = 2
-			displayName_english = "All of them! [shattered world!]"
-			displayName_french = "Tous! [monde brisé!]"
-			tooltip_english = "All empires are broken down."
-			tooltip_french = "Tous les empires sont détruits."
+			displayName = OP3R2
+			tooltip = OP3R2TIP
 			default = false
 		}
 		radioOption = {
 			name = 3
-			displayName_english = "Defined in shatter_empires.txt"
-			displayName_french = "Défini dans shatter_empires.txt"
-			tooltip_english = "As defined manually."
-			tooltip_french = "Comme défini manuellement."
+			displayName = OP3R3
+			tooltip = OP3R3TIP
 			default = false
 		}
 	}
 }
 option = {
 	name = shatter_level
-	displayName_english = "If we're shattering non-HRE empires, how far down do we go?"
-	displayName_french = "Si nous détruisons des empires non-EDH, jusqu'où allons-nous?"
-	tooltip_english = "More the merrier."
-	tooltip_french = "Plus on est de fous."
+	displayName = OPTION4
+	tooltip = OPTION4TIP
 	radioSelector = {
 		radioOption = {
 			name = 1
-			displayName_english = "Down to duchies."
-			displayName_french = "Jusqu'aux duchés."
-			tooltip_english = "Duchies make sense."
-			tooltip_french = "Les duchés ont du sens."
+			displayName = OP4R1
+			tooltip = OP4R1TIP
 			default = true
 		}
 		radioOption = {
 			name = 2
-			displayName_english = "Keep kingdoms if any."
-			displayName_french = "Gardez les royaumes le cas échéant."
-			tooltip_english = "Kingdoms remain."
-			tooltip_french = "Les royaumes restent."
+			displayName = OP4R2
+			tooltip = OP4R2TIP
 			default = false
 		}
 	}
 }
 option = {
 	name = development
-	displayName_english = "How do we handle province development?"
-	displayName_french = "Comment gérons-nous le développement de la province?"
-	tooltip_english = "Should we stick to vanilla or import CK2?"
-	tooltip_french = "Faut-il s'en tenir à la vanille ou importer du CK2?"
+	displayName = OPTION5
+	tooltip = OPTION5TIP
 	radioSelector = {
 		radioOption = {
 			name = 1
-			displayName_english = "Use CK2 provinces' development."
-			displayName_french = "Utiliser le développement des provinces CK2."
-			tooltip_english = "The proper way."
-			tooltip_french = "La bonne façon."
+			displayName = OP5R1
+			tooltip = OP5R1TIP
 			default = true
 		}
 		radioOption = {
 			name = 2
-			displayName_english = "No, stick to EU4 vanilla ['ahistorical']"
-			displayName_french = "Non, respectez la vanille EU4 ['ahistorique']"
-			tooltip_english = "Leave as is."
-			tooltip_french = "Laissez tel quel."
+			displayName = OP5R2
+			tooltip = OP5R2TIP
 			default = false
 		}
 	}
 }
 option = {
 	name = siberia
-	displayName_english = "Clear Siberian Quagmire?"
-	displayName_french = "Clair bourbier de Sibérie?"
-	tooltip_english = "Delete all the nomads and tribals?"
-	tooltip_french = "Supprimer tous les nomades et tribaux?"
+	displayName = OPTION6
+	tooltip = OPTION6TIP
 	radioSelector = {
 		radioOption = {
 			name = 1
-			displayName_english = "Burn it all down [default]"
-			displayName_french = "Gravez le tout [par défaut]"
-			tooltip_english = "Clean Siberia."
-			tooltip_french = "La Sibérie propre."
+			displayName = OP6R1
+			tooltip = OP6R1TIP
 			default = true
 		}
 		radioOption = {
 			name = 2
-			displayName_english = "No, I was playing those! [hampers Russia]"
-			displayName_french = "Non, je jouais ça! [entrave la Russie]"
-			tooltip_english = "Leave as is."
-			tooltip_french = "Laissez tel quel."
+			displayName = OP6R2
+			tooltip = OP6R2TIP
 			default = false
 		}
 	}
 }
 option = {
 	name = sunset
-	displayName_english = "Should we touch Sunset?"
-	displayName_french = "Faut-il toucher le coucher du soleil?"
-	tooltip_english = "How should we deal with Sunset?"
-	tooltip_french = "Comment devons-nous gérer le coucher du soleil?"
+	displayName = OPTION7
+	tooltip = OPTION7TIP
 	radioSelector = {
 		radioOption = {
 			name = 1
-			displayName_english = "As-is, inherit CK2 state."
-			displayName_french = "En l'état, héritez de l'état CK2."
-			tooltip_english = "Change nothing."
-			tooltip_french = "Ne change rien."
+			displayName = OP7R1
+			tooltip = OP7R1TIP
 			default = true
 		}
 		radioOption = {
 			name = 2
-			displayName_english = "Get rid of them!"
-			displayName_french = "Se débarrasser d'eux!"
-			tooltip_english = "Reset to vanilla state."
-			tooltip_french = "Rétablir l'état vanille."
+			displayName = OP7R2
+			tooltip = OP7R2TIP
 			default = false
 		}
 		radioOption = {
 			name = 3
-			displayName_english = "No, no, I WANT the Sunset active!"
-			displayName_french = "Non, non, JE VEUX que le coucher du soleil soit actif!"
-			tooltip_english = "Enforce Sunset."
-			tooltip_french = "Appliquer le coucher du soleil."
+			displayName = OP7R3
+			tooltip = OP7R3TIP
 			default = false
 		}
 	}
 }
 option = {
 	name = output_name
-	displayName_english = "Mod Output Name (optional):"
-	displayName_french = "Nom de sortie du module (facultatif):"
-	tooltip_english = "Please don't use cyrillic or chinese..."
-	tooltip_french = "Veuillez ne pas utiliser cyrillique ou chinois ..."
+	displayName = OPTION8
+	tooltip = OPTION8TIP
 	textSelector = {	
 		value = ""
 		editable = true
-		tooltip_english = "Optional name for the converted mod."
-		tooltip_french = "Nom facultatif pour le mod converti."
+		tooltip = OPTION8TEXTTIP
 	}
 }

--- a/Fronter/Source/Configuration/Configuration.h
+++ b/Fronter/Source/Configuration/Configuration.h
@@ -9,8 +9,8 @@
 class Configuration: commonItems::parser
 {
   public:
-	Configuration(const std::string& language);
-	explicit Configuration(std::istream& theStream, const std::string& language);
+	Configuration();
+	explicit Configuration(std::istream& theStream);
 
 	[[nodiscard]] const auto& getSourceGame() const { return sourceGame; }
 	[[nodiscard]] const auto& getTargetGame() const { return targetGame; }
@@ -26,9 +26,7 @@ class Configuration: commonItems::parser
 	
   private:
 	void registerKeys();
-	void registerLanguageKeys();
 	void registerPreloadKeys();
-	void useLanguage(const std::string& language);
 
 	std::string name;
 	std::string converterFolder;
@@ -39,8 +37,6 @@ class Configuration: commonItems::parser
 	std::map<std::string, std::shared_ptr<RequiredFolder>> requiredFolders;
 	std::vector<std::shared_ptr<Option>> options;
 	int optionCounter = 0;
-
-	std::string setLanguage = "english";
 };
 
 #endif // CONFIGURATION

--- a/Fronter/Source/Configuration/Options/Option.cpp
+++ b/Fronter/Source/Configuration/Options/Option.cpp
@@ -2,7 +2,7 @@
 #include "Log.h"
 #include "ParserHelpers.h"
 
-Option::Option(std::istream& theStream, int theID, std::string language): ID(theID), setLanguage(std::move(language))
+Option::Option(std::istream& theStream, int theID): ID(theID)
 {
 	registerKeys();
 	parseStream(theStream);
@@ -15,20 +15,20 @@ void Option::registerKeys()
 		const commonItems::singleString nameStr(theStream);
 		name = nameStr.getString();
 	});
-	registerKeyword("tooltip_" + setLanguage, [this](const std::string& unused, std::istream& theStream) {
+	registerKeyword("tooltip", [this](const std::string& unused, std::istream& theStream) {
 		const commonItems::singleString tooltipStr(theStream);
 		tooltip = tooltipStr.getString();
 	});
-	registerKeyword("displayName_" + setLanguage, [this](const std::string& unused, std::istream& theStream) {
+	registerKeyword("displayName", [this](const std::string& unused, std::istream& theStream) {
 		const commonItems::singleString nameStr(theStream);
 		displayName = nameStr.getString();
 	});
 	registerKeyword("radioSelector", [this](const std::string& unused, std::istream& theStream) {
-		auto newSelector = std::make_shared<RadioSelector>(theStream, setLanguage);
+		auto newSelector = std::make_shared<RadioSelector>(theStream);
 		radioSelector = std::pair(true, newSelector);
 	});
 	registerKeyword("textSelector", [this](const std::string& unused, std::istream& theStream) {
-		auto newSelector = std::make_shared<TextSelector>(theStream, setLanguage);
+		auto newSelector = std::make_shared<TextSelector>(theStream);
 		textSelector = std::pair(true, newSelector);
 	});
 	registerRegex("[A-Za-z0-9:_\\.-]+", commonItems::ignoreItem);

--- a/Fronter/Source/Configuration/Options/Option.h
+++ b/Fronter/Source/Configuration/Options/Option.h
@@ -8,7 +8,7 @@ class Option: commonItems::parser
 {
   public:
 	Option() = default;
-	explicit Option(std::istream& theStream, int theID, std::string language);
+	explicit Option(std::istream& theStream, int theID);
 
 	[[nodiscard]] const auto& getName() const { return name; }
 	[[nodiscard]] const auto& getDisplayName() const { return displayName; }
@@ -33,8 +33,6 @@ class Option: commonItems::parser
 	std::string displayName;
 	std::pair<bool, std::shared_ptr<RadioSelector>> radioSelector; // enabled, selector.
 	std::pair<bool, std::shared_ptr<TextSelector>> textSelector;	// enabled, selector.
-
-	std::string setLanguage;
 };
 
 #endif // CONFIGURATION_OPTION

--- a/Fronter/Source/Configuration/Options/RadioOption.cpp
+++ b/Fronter/Source/Configuration/Options/RadioOption.cpp
@@ -2,7 +2,7 @@
 #include "Log.h"
 #include "ParserHelpers.h"
 
-RadioOption::RadioOption(std::istream& theStream, int theID, std::string language): ID(theID), setLanguage(std::move(language))
+RadioOption::RadioOption(std::istream& theStream, int theID): ID(theID)
 {
 	registerKeys();
 	parseStream(theStream);
@@ -15,11 +15,11 @@ void RadioOption::registerKeys()
 		const commonItems::singleString nameStr(theStream);
 		name = nameStr.getString();
 	});
-	registerKeyword("tooltip_" + setLanguage, [this](const std::string& unused, std::istream& theStream) {
+	registerKeyword("tooltip", [this](const std::string& unused, std::istream& theStream) {
 		const commonItems::singleString tooltipStr(theStream);
 		tooltip = tooltipStr.getString();
 	});
-	registerKeyword("displayName_" + setLanguage, [this](const std::string& unused, std::istream& theStream) {
+	registerKeyword("displayName", [this](const std::string& unused, std::istream& theStream) {
 		const commonItems::singleString nameStr(theStream);
 		displayName = nameStr.getString();
 	});

--- a/Fronter/Source/Configuration/Options/RadioOption.h
+++ b/Fronter/Source/Configuration/Options/RadioOption.h
@@ -6,7 +6,7 @@ class RadioOption: commonItems::parser
 {
   public:
 	RadioOption() = default;
-	explicit RadioOption(std::istream& theStream, int theID, std::string language);
+	explicit RadioOption(std::istream& theStream, int theID);
 
 	[[nodiscard]] const auto& getName() const { return name; }
 	[[nodiscard]] const auto& getDisplayName() const { return displayName; }
@@ -27,8 +27,6 @@ class RadioOption: commonItems::parser
 	std::string name;
 	std::string tooltip;
 	std::string displayName;
-
-	std::string setLanguage;
 };
 
 #endif // CONFIGURATION_RADIO_OPTION

--- a/Fronter/Source/Configuration/Options/RadioSelector.cpp
+++ b/Fronter/Source/Configuration/Options/RadioSelector.cpp
@@ -2,7 +2,7 @@
 #include "Log.h"
 #include "ParserHelpers.h"
 
-RadioSelector::RadioSelector(std::istream& theStream, std::string language): setLanguage(std::move(language))
+RadioSelector::RadioSelector(std::istream& theStream)
 {
 	registerKeys();
 	parseStream(theStream);
@@ -13,7 +13,7 @@ void RadioSelector::registerKeys()
 {
 	registerKeyword("radioOption", [this](const std::string& unused, std::istream& theStream) {
 		optionCounter++;
-		auto newOption = std::make_shared<RadioOption>(theStream, optionCounter, setLanguage);
+		auto newOption = std::make_shared<RadioOption>(theStream, optionCounter);
 		radioOptions.emplace_back(newOption);
 	});
 	registerRegex("[A-Za-z0-9:_\\.-]+", commonItems::ignoreItem);

--- a/Fronter/Source/Configuration/Options/RadioSelector.h
+++ b/Fronter/Source/Configuration/Options/RadioSelector.h
@@ -7,7 +7,7 @@ class RadioSelector: commonItems::parser
 {
   public:
 	RadioSelector() = default;
-	explicit RadioSelector(std::istream& theStream, std::string language);
+	explicit RadioSelector(std::istream& theStream);
 
 	[[nodiscard]] const auto& getOptions() const { return radioOptions; }
 	[[nodiscard]] auto getID() const { return ID; }
@@ -24,7 +24,6 @@ class RadioSelector: commonItems::parser
 	int ID = 0;
 	int optionCounter = 0;
 	std::vector<std::shared_ptr<RadioOption>> radioOptions;
-	std::string setLanguage;
 };
 
 #endif // CONFIGURATION_RADIO_SELECTOR

--- a/Fronter/Source/Configuration/Options/TextSelector.cpp
+++ b/Fronter/Source/Configuration/Options/TextSelector.cpp
@@ -2,7 +2,7 @@
 #include "Log.h"
 #include "ParserHelpers.h"
 
-TextSelector::TextSelector(std::istream& theStream, std::string language): setLanguage(std::move(language))
+TextSelector::TextSelector(std::istream& theStream)
 {
 	registerKeys();
 	parseStream(theStream);
@@ -19,7 +19,7 @@ void TextSelector::registerKeys()
 		const commonItems::singleString valueStr(theStream);
 		value = valueStr.getString();
 	});
-	registerKeyword("tooltip_" + setLanguage, [this](const std::string& unused, std::istream& theStream) {
+	registerKeyword("tooltip", [this](const std::string& unused, std::istream& theStream) {
 		const commonItems::singleString tooltipStr(theStream);
 		tooltip = tooltipStr.getString();
 	});

--- a/Fronter/Source/Configuration/Options/TextSelector.h
+++ b/Fronter/Source/Configuration/Options/TextSelector.h
@@ -6,7 +6,7 @@ class TextSelector: commonItems::parser
 {
   public:
 	TextSelector() = default;
-	explicit TextSelector(std::istream& theStream, std::string language);
+	explicit TextSelector(std::istream& theStream);
 
 	[[nodiscard]] const auto& getValue() const { return value; }
 	[[nodiscard]] const auto& getTooltip() const { return tooltip; }
@@ -23,7 +23,6 @@ class TextSelector: commonItems::parser
 	int ID = 0;
 	std::string value;
 	std::string tooltip;
-	std::string setLanguage;
 };
 
 #endif // CONFIGURATION_TEXT_SELECTOR

--- a/Fronter/Source/Configuration/RequiredFile.cpp
+++ b/Fronter/Source/Configuration/RequiredFile.cpp
@@ -2,7 +2,7 @@
 #include "Log.h"
 #include "ParserHelpers.h"
 
-RequiredFile::RequiredFile(std::istream& theStream, std::string language): setLanguage(std::move(language))
+RequiredFile::RequiredFile(std::istream& theStream)
 {
 	registerKeys();
 	parseStream(theStream);
@@ -15,11 +15,11 @@ void RequiredFile::registerKeys()
 		const commonItems::singleString nameStr(theStream);
 		name = nameStr.getString();
 	});
-	registerKeyword("tooltip_" + setLanguage, [this](const std::string& unused, std::istream& theStream) {
+	registerKeyword("tooltip", [this](const std::string& unused, std::istream& theStream) {
 		const commonItems::singleString tooltipStr(theStream);
 		tooltip = tooltipStr.getString();
 	});
-	registerKeyword("displayName_" + setLanguage, [this](const std::string& unused, std::istream& theStream) {
+	registerKeyword("displayName", [this](const std::string& unused, std::istream& theStream) {
 		const commonItems::singleString nameStr(theStream);
 		displayName = nameStr.getString();
 	});

--- a/Fronter/Source/Configuration/RequiredFile.h
+++ b/Fronter/Source/Configuration/RequiredFile.h
@@ -6,7 +6,7 @@ class RequiredFile: commonItems::parser
 {
   public:
 	RequiredFile() = default;
-	explicit RequiredFile(std::istream& theStream, std::string language);
+	explicit RequiredFile(std::istream& theStream);
 
 	[[nodiscard]] const auto& getName() const { return name; }
 	[[nodiscard]] const auto& getDisplayName() const { return displayName; }
@@ -37,8 +37,6 @@ class RequiredFile: commonItems::parser
 	std::string fileName;
 	std::string allowedExtension;
 	std::string value;
-
-	std::string setLanguage;
 };
 
 #endif // CONFIGURATION_REQUIRED_FILE

--- a/Fronter/Source/Configuration/RequiredFolder.cpp
+++ b/Fronter/Source/Configuration/RequiredFolder.cpp
@@ -2,7 +2,7 @@
 #include "Log.h"
 #include "ParserHelpers.h"
 
-RequiredFolder::RequiredFolder(std::istream& theStream, std::string language): setLanguage(std::move(language))
+RequiredFolder::RequiredFolder(std::istream& theStream)
 {
 	registerKeys();
 	parseStream(theStream);
@@ -15,11 +15,11 @@ void RequiredFolder::registerKeys()
 		const commonItems::singleString nameStr(theStream);
 		name = nameStr.getString();
 	});
-	registerKeyword("tooltip_" + setLanguage, [this](const std::string& unused, std::istream& theStream) {
+	registerKeyword("tooltip", [this](const std::string& unused, std::istream& theStream) {
 		const commonItems::singleString tooltipStr(theStream);
 		tooltip = tooltipStr.getString();
 	});
-	registerKeyword("displayName_" + setLanguage, [this](const std::string& unused, std::istream& theStream) {
+	registerKeyword("displayName", [this](const std::string& unused, std::istream& theStream) {
 		const commonItems::singleString nameStr(theStream);
 		displayName = nameStr.getString();
 	});

--- a/Fronter/Source/Configuration/RequiredFolder.h
+++ b/Fronter/Source/Configuration/RequiredFolder.h
@@ -6,7 +6,7 @@ class RequiredFolder: commonItems::parser
 {
   public:
 	RequiredFolder() = default;
-	explicit RequiredFolder(std::istream& theStream, std::string language);
+	explicit RequiredFolder(std::istream& theStream);
 
 	void setID(int theID) { ID = theID; }
 	void setValue(const std::string& theValue) { value = theValue; }
@@ -36,8 +36,6 @@ class RequiredFolder: commonItems::parser
 	std::string searchPath;
 	std::string searchPathID;
 	std::string value;
-
-	std::string setLanguage;
 };
 
 #endif // CONFIGURATION_REQUIRED_FOLDER

--- a/Fronter/Source/Frames/MainFrame.cpp
+++ b/Fronter/Source/Frames/MainFrame.cpp
@@ -28,6 +28,7 @@ void MainFrame::initFrame()
 
 	optionsTab = new OptionsTab(notebook);
 	optionsTab->loadConfiguration(configuration);
+	optionsTab->loadLocalization(localization);
 	optionsTab->initializeOptions();
 	optionsTab->SetBackgroundColour(wxColour(245, 255, 245));
 

--- a/Fronter/Source/Frames/Tabs/OptionBox.cpp
+++ b/Fronter/Source/Frames/Tabs/OptionBox.cpp
@@ -5,7 +5,7 @@
 #include <codecvt>
 #include <wx/textctrl.h>
 #include "../../Utils/OSFunctions.h"
-#include "OSCompatibilityLayer.h"
+#define tr localization->translate
 
 OptionBox::OptionBox(wxWindow* parent, const std::string& theName, std::shared_ptr<Option> theOption):
 	 wxWindow(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxEXPAND), optionName(theName)
@@ -29,8 +29,8 @@ void OptionBox::initializeOption()
 	boxHolder->SetSizer(flexGridSizer);
 	boxHolder->SetBackgroundColour(wxColour(230, 230, 230));
 
-	wxStaticText* st = new wxStaticText(boxHolder, wxID_ANY, Utils::convertUTF8ToUTF16(option->getDisplayName()), wxDefaultPosition, wxDefaultSize);
-	st->SetToolTip(Utils::convertUTF8ToUTF16(option->getTooltip()));
+	wxStaticText* st = new wxStaticText(boxHolder, wxID_ANY, tr(option->getDisplayName()), wxDefaultPosition, wxDefaultSize);
+	st->SetToolTip(tr(option->getTooltip()));
 	flexGridSizer->Add(st, wxSizerFlags(1).Border(wxALL, 5));
 	st->SetMinSize(wxSize(260, -1));
 	st->Wrap(260);
@@ -44,14 +44,14 @@ void OptionBox::initializeOption()
 			if (first)
 			{
 				theButton =
-					 new wxRadioButton(boxHolder, radioOption->getID(), Utils::convertUTF8ToUTF16(radioOption->getDisplayName()), wxDefaultPosition, wxDefaultSize, wxRB_GROUP | wxEXPAND);
+					 new wxRadioButton(boxHolder, radioOption->getID(), tr(radioOption->getDisplayName()), wxDefaultPosition, wxDefaultSize, wxRB_GROUP | wxEXPAND);
 				first = false;
 			}
 			else
 			{
-				theButton = new wxRadioButton(boxHolder, radioOption->getID(), Utils::convertUTF8ToUTF16(radioOption->getDisplayName()), wxDefaultPosition, wxDefaultSize, wxEXPAND);
+				theButton = new wxRadioButton(boxHolder, radioOption->getID(), tr(radioOption->getDisplayName()), wxDefaultPosition, wxDefaultSize, wxEXPAND);
 			}
-			theButton->SetToolTip(Utils::convertUTF8ToUTF16(radioOption->getTooltip()));
+			theButton->SetToolTip(tr(radioOption->getTooltip()));
 			if (!option->getRadioSelector().second->getSelectedValue().empty() &&
 				 option->getRadioSelector().second->getSelectedID() == radioOption->getID())
 			{
@@ -84,7 +84,7 @@ void OptionBox::initializeOption()
 			flag = wxBORDER_DEFAULT | wxTE_READONLY;
 		}
 		textField = new wxTextCtrl(boxHolder, wxID_ANY, selector->getValue(), wxDefaultPosition, wxDefaultSize, flag);
-		textField->SetToolTip(Utils::convertUTF8ToUTF16(selector->getTooltip()));
+		textField->SetToolTip(tr(selector->getTooltip()));
 
 		textField->Bind(wxEVT_TEXT, [this](wxCommandEvent& event) {
 			const auto result = UTF16ToUTF8(event.GetString().ToStdWstring());

--- a/Fronter/Source/Frames/Tabs/OptionBox.h
+++ b/Fronter/Source/Frames/Tabs/OptionBox.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <wx/wxprec.h>
+#include "../../Utils/Localization/Localization.h"
 #ifndef WX_PRECOMP
 #include <wx/wx.h>
 #endif
@@ -14,9 +15,11 @@ class OptionBox: public wxWindow
 
 	void loadOption(std::shared_ptr<Option> theOption) { option = theOption; }
 	void initializeOption();
-	
+	void loadLocalization(std::shared_ptr<Localization> theLocalization) { localization = std::move(theLocalization); }
+
   private:
 	std::string optionName;
 	std::shared_ptr<Option> option;
 	wxTextCtrl* textField = nullptr;
+	std::shared_ptr<Localization> localization;
 };

--- a/Fronter/Source/Frames/Tabs/OptionsTab.cpp
+++ b/Fronter/Source/Frames/Tabs/OptionsTab.cpp
@@ -17,6 +17,7 @@ void OptionsTab::initializeOptions()
 	for (const auto option: configuration->getOptions())
 	{
 		OptionBox* newOption = new OptionBox(this, option->getName(), option);
+		newOption->loadLocalization(localization);
 		newOption->initializeOption();
 		optionsTabSizer->Add(newOption);
 	}

--- a/Fronter/Source/Frames/Tabs/OptionsTab.h
+++ b/Fronter/Source/Frames/Tabs/OptionsTab.h
@@ -4,6 +4,7 @@
 #include <wx/wx.h>
 #endif
 #include "../../Configuration/Configuration.h"
+#include "../../Utils/Localization/Localization.h"
 
 class OptionsTab: public wxScrolledWindow
 {
@@ -12,7 +13,9 @@ class OptionsTab: public wxScrolledWindow
 
 	void loadConfiguration(std::shared_ptr<Configuration> theConfiguration) { configuration = theConfiguration; }
 	void initializeOptions();
+	void loadLocalization(std::shared_ptr<Localization> theLocalization) { localization = std::move(theLocalization); }
 
   private:
 	std::shared_ptr<Configuration> configuration;
+	std::shared_ptr<Localization> localization;
 };

--- a/Fronter/Source/Frames/Tabs/PathsTab.cpp
+++ b/Fronter/Source/Frames/Tabs/PathsTab.cpp
@@ -24,7 +24,7 @@ void PathsTab::initializePaths()
 		if (!folder.second->isMandatory())
 			continue;
 		pickerCounter++;
-		wxStaticText* st = new wxStaticText(this, wxID_ANY, Utils::convertUTF8ToUTF16(folder.second->getDisplayName()), wxDefaultPosition);
+		wxStaticText* st = new wxStaticText(this, wxID_ANY, tr(folder.second->getDisplayName()), wxDefaultPosition);
 
 		std::string folderPath;
 		if (!folder.second->getValue().empty())
@@ -52,7 +52,7 @@ void PathsTab::initializePaths()
 		dirPickerCtrl->SetInitialDirectory(wxString(folderPath));
 		folder.second->setID(pickerCounter);
 		folder.second->setValue(folderPath);
-		st->SetToolTip(Utils::convertUTF8ToUTF16(folder.second->getTooltip()));
+		st->SetToolTip(tr(folder.second->getTooltip()));
 		GetSizer()->Add(st, 0, wxLEFT | wxRIGHT | wxALIGN_CENTER_VERTICAL, 5, nullptr);
 		GetSizer()->Add(dirPickerCtrl, 0, wxLEFT | wxRIGHT | wxEXPAND | wxALIGN_CENTER_VERTICAL, 5, nullptr);
 	}
@@ -62,7 +62,7 @@ void PathsTab::initializePaths()
 		if (!file.second->isMandatory())
 			continue;
 		pickerCounter++;
-		wxStaticText* st = new wxStaticText(this, wxID_ANY, Utils::convertUTF8ToUTF16(file.second->getDisplayName()), wxDefaultPosition);
+		wxStaticText* st = new wxStaticText(this, wxID_ANY, tr(file.second->getDisplayName()), wxDefaultPosition);
 
 		std::string filePath;
 		std::string initialPath;
@@ -97,7 +97,7 @@ void PathsTab::initializePaths()
 			 wxFLP_USE_TEXTCTRL | wxFLP_SMALL);
 		filePickerCtrl->Bind(wxEVT_FILEPICKER_CHANGED, &PathsTab::OnPathChanged, this);
 		filePickerCtrl->SetInitialDirectory(wxString(initialPath));
-		st->SetToolTip(Utils::convertUTF8ToUTF16(file.second->getTooltip()));
+		st->SetToolTip(tr(file.second->getTooltip()));
 		file.second->setID(pickerCounter);
 		file.second->setValue(filePath);
 		GetSizer()->Add(st, 0, wxLEFT | wxRIGHT | wxALIGN_CENTER_VERTICAL, 5, nullptr);

--- a/Fronter/Source/Frontend.cpp
+++ b/Fronter/Source/Frontend.cpp
@@ -7,10 +7,10 @@ wxIMPLEMENT_APP(Frontend);
 bool Frontend::OnInit()
 {
 	localization = std::make_shared<Localization>();
-	configuration = std::make_shared<Configuration>(localization->getSetLanguage());
+	configuration = std::make_shared<Configuration>();
 	
 	MainFrame* frame =
-		 new MainFrame(tr("TITLETITLE") + configuration->getSourceGame() + tr("TITLETO") + configuration->getTargetGame(), wxPoint(50, 50), wxSize(1200, 600));
+		 new MainFrame(tr("TITLETITLE") + tr(configuration->getSourceGame()) + tr("TITLETO") + tr(configuration->getTargetGame()), wxPoint(50, 50), wxSize(1200, 600));
 	frame->loadConfiguration(configuration);
 	frame->loadLocalization(localization);
 	frame->initFrame();

--- a/Fronter/Source/Utils/Localization/Localization.cpp
+++ b/Fronter/Source/Utils/Localization/Localization.cpp
@@ -23,6 +23,7 @@ Localization::Localization()
 		const auto secpos = line.find_last_of('\"');
 		auto langtext = line.substr(pos + 1, secpos - pos - 1);
 		languages.insert(std::pair(language, langtext));
+		loadedLangauges.emplace_back(language);
 	}
 	langfile.close();
 	loadLanguages();
@@ -41,33 +42,34 @@ Localization::Localization()
 
 void Localization::loadLanguages()
 {
-	for (const auto& language: languages)
+	std::set<std::string> fileNames;
+	Utils::GetAllFilesInFolder("Configuration/", fileNames);
+
+	for (const auto& fileName: fileNames)
 	{
-		if (!fs::exists("Configuration/converter_l_" + language.first + ".yml"))
-		{
-			Log(LogLevel::Error) << "Configuration/converter_l_" + language.first + ".yml not found !";
+		if (fileName.find(".yml") == std::string::npos)
 			continue;
-		}
-		std::ifstream langfile("Configuration/converter_l_" + language.first + ".yml");
+		std::ifstream langfile("Configuration/" + fileName);
 		std::string line;
 		std::getline(langfile, line);
-		if (line.find("l_" + language.first + ":") != 0)
+		if (line.find("l_") != 0)
 		{
-			Log(LogLevel::Error) << "Configuration/converter_l_" + language.first + ".yml holds wrong language!";
+			Log(LogLevel::Error) << "Configuration/" << fileName << " is not a localization file!";
 			langfile.close();
 			continue;
 		}
+		auto pos = line.find(':');
+		const auto language = line.substr(2, pos - 2);
 		while (std::getline(langfile, line))
 		{
-			auto pos = line.find_first_of(':');
+			pos = line.find_first_of(':');
 			auto key = line.substr(1, pos - 1);
 			pos = line.find_first_of('\"');
 			const auto secpos = line.find_last_of('\"');
 			auto text = line.substr(pos + 1, secpos - pos - 1);
-			translations[key].insert(std::pair(language.first, text));
+			translations[key].insert(std::pair(language, text));
 		}
 		langfile.close();
-		loadedLangauges.emplace_back(language.first);
 	}
 }
 

--- a/README.md
+++ b/README.md
@@ -18,23 +18,16 @@ but Fronter will whine if it can't find either. It's better to have them separat
 #### fronter-configuration.txt
 
 ```
-supportedLocLanguages = { english french } # Keep this line at the top.
-
 name = CK2ToEU4
 converterFolder = CK2ToEU4
-displayName_english = "Crusader Kings II To Europa Universalis IV"
-displayName_french = "Crusader Kings II à Europa Universalis IV"
-sourceGame_english = "Crusader Kings II"
-sourceGame_french = "Crusader Kings II"
-targetGame_english = "Europa Universalis IV"
-targetGame_french = "Europa Universalis IV"
+displayName = DISPLAYNAME
+sourceGame = SOURCEGAME
+targetGame = TARGETGAME
 
 requiredFile = {
 	name = SaveGame
-	displayName_english = "Path to the CK2 Savegame"
-	displayName_french = "Chemin vers le jeu de sauvegarde CK2"
-	tooltip_english = "Path to your savegame from CK2"
-	tooltip_french = "Chemin vers votre sauvegarde depuis CK2"
+	displayName = FILE2
+	tooltip = FILE2TIP
 	mandatory = true
 	outputtable = true
 	searchPathType = windowsUsersFolder
@@ -42,12 +35,22 @@ requiredFile = {
 	allowedExtension = "*.ck2"
 }
 
+requiredFile = {
+	name = converterExe
+	displayName = FILE1
+	tooltip = FILE1TIP
+	mandatory = true
+	outputtable = false
+	searchPathType = converterFolder
+	searchPath = "CK2ToEU4"
+	allowedExtension = "*.exe"
+	fileName = "CK2ToEU4Converter.exe"
+}
+
 requiredFolder = {
 	name = CK2directory
-	displayName_english = "Crusader Kings II Install directory"
-	displayName_french = "Répertoire d'installation de Crusader Kings II"
-	tooltip_english = "A path on your computer where Crusader Kings 2 is installed"
-	tooltip_french = "Un chemin sur votre ordinateur où Crusader Kings 2 est installé"
+	displayName = FOLDER1
+	tooltip = FOLDER1TIP
 	mandatory = true
 	searchPathType = steamFolder
 	searchPathID = 203770
@@ -55,15 +58,12 @@ requiredFolder = {
 
 requiredFolder = {
 	name = targetGameModPath
-	displayName_english = "Europa Universalis IV Mods directory"
-	displayName_french = "Répertoire des Mods Europa Universalis IV"
-	tooltip_english = "A path on your computer where Europa Universalis IV keeps mods"
-	tooltip_french = "Un chemin sur votre ordinateur où Europa Universalis IV conserve les mods"
+	displayName = FOLDER4
+	tooltip = FOLDER4TIP
 	mandatory = true
 	searchPathType = windowsUsersFolder
 	searchPath = "Paradox Interactive\Europa Universalis IV\mod"
 }
-
 ```
 
 searchPathType:
@@ -85,25 +85,19 @@ Rest is self-explanatory! Shoestring Budget!
 ```
 option = {
 	name = shatter_hre_level
-	displayName_english = "If we're shattering HRE, how far down do we go?"
-	displayName_french = "Si nous brisons l'EDH, jusqu'où allons-nous?"
-	tooltip_english = "HRE should be shattered to duchies as it increases prince number and thus stability."
-	tooltip_french = "L'EDH devrait être brisée en duchés car elle augmente le nombre de prince et donc la stabilité."
+	displayName = OPTION2
+	tooltip = OPTION2TIP
 	radioSelector = {
 		radioOption = {
 			name = 1
-			displayName_english = "Down to duchies [default]"
-			displayName_french = "Jusqu'aux duchés [par défaut]"
-			tooltip_english = "Need Duchies for stability."
-			tooltip_french = "Besoin de duchés pour la stabilité."
+			displayName = OP2R1
+			tooltip = OP2R1TIP
 			default = true
 		}
 		radioOption = {
 			name = 2
-			displayName_english = "Keep kingdoms if any [not recommended]"
-			displayName_french = "Gardez les royaumes le cas échéant [non recommandé]"
-			tooltip_english = "Kingdoms remain."
-			tooltip_french = "Les royaumes restent."
+			displayName = OP2R2
+			tooltip = OP2R2TIP
 			default = false
 		}
 	}
@@ -111,29 +105,46 @@ option = {
 
 option = {
 	name = output_name
-	displayName_english = "Mod Output Name (optional):"
-	displayName_french = "Nom de sortie du module (facultatif):"
-	tooltip_english = "Please don't use cyrillic or chinese..."
-	tooltip_french = "Veuillez ne pas utiliser cyrillique ou chinois ..."
+	displayName = OPTION8
+	tooltip = OPTION8TIP
 	textSelector = {	
 		value = ""
 		editable = true
-		tooltip_english = "Optional name for the converted mod."
-		tooltip_french = "Nom facultatif pour le mod converti."
+		tooltip = OPTION8TEXTTIP
 	}
 }
-
 ```
 
 Entirely self-explanatory. Why waste words on such simplicity.
 
 #### Localization
 
-If the Fronter is running in some language not supported by configuration, it will load english lines. That's what that first line of first file is for.
+Fronter expects to find appropriate yml files in Configuration/ directory. yml files look like this:
 
-Also, unless the frontend itself is taught how to speak Russian through converter_l_russian.yml and expanded converter_languages.yml, inserting Russian localizations here won't make a bit of difference.
+```l_french:
+ DISPLAYNAME: "Crusader Kings II à Europa Universalis IV"
+ SOURCEGAME: "Crusader Kings II"
+ TARGETGAME: "Europa Universalis IV"
+ FOLDER1: "Répertoire d'installation de Crusader Kings II"
+ FOLDER1TIP: "Un chemin sur votre ordinateur où Crusader Kings 2 est installé"
+```
+or
+```
+l_english:
+ OPTION1: "Which empire inherits EU4 HRE mechanics and shatters?"
+ OPTION1TIP: "Only one empire can use HRE mechanics."
+ OP1R1: "The HRE [obviously]"
+ OP1R1TIP: "e_hre"
+ OP1R2: "Byzantium! [Holy and Roman and Empire]"
+```
 
-Also also, the french displayed is totally not a product of googletranslate but carefully broken to demonstrate the need for professional help.
+Yml files need to be encoded in UTF-8, not UTF-8-BOM.
+
+Fronter will load the files (regardless of their actual name) and use `l_language:` to file the key-value pairs under appropriate language.
+Whenever configuration or options use these keys, it will attempt to load appropriate localization string to be displayed.
+
+If it fails to find a key-pair under a specific language, it will default to english. If there's no english either, it will display a blank string. 
+Look for these blank strings to see where you made a typo.
 
 #### cofiguration.txt
 


### PR DESCRIPTION
* Simplification and streamlining of localization loading and use.
* Fronter loads all yml files and no longer fusses.
* Configuration is again simplified to the point of triviality, as internal localization is removed.