### PR TITLE
Fix for empty lines in loc crashing the frontend

### DIFF
--- a/Fronter/Source/Utils/Localization/Localization.cpp
+++ b/Fronter/Source/Utils/Localization/Localization.cpp
@@ -18,6 +18,7 @@ Localization::Localization()
 	while (std::getline(langfile, line))
 	{
 		auto pos = line.find_first_of(':');
+		if (pos == std::string::npos) continue;
 		auto language = line.substr(2, pos - 2);
 		pos = line.find_first_of('\"');
 		const auto secpos = line.find_last_of('\"');
@@ -62,6 +63,7 @@ void Localization::loadLanguages()
 		while (std::getline(langfile, line))
 		{
 			pos = line.find_first_of(':');
+			if (pos == std::string::npos) continue;
 			auto key = line.substr(1, pos - 1);
 			pos = line.find_first_of('\"');
 			const auto secpos = line.find_last_of('\"');


### PR DESCRIPTION
Frontend should now handle empty lines in yml localization files.