### PR TITLE
Major fixes and improvements:

### DIFF
--- a/Fronter/Source/Configuration/Configuration.cpp
+++ b/Fronter/Source/Configuration/Configuration.cpp
@@ -7,7 +7,7 @@ namespace fs = std::filesystem;
 
 Configuration::Configuration()
 {
-	std::ofstream clearLog("log.txt", std::ofstream::trunc);
+	std::ofstream clearLog("log.txt");
 	clearLog.close();
 	registerKeys();
 	if (fs::exists("Configuration/fronter-configuration.txt"))
@@ -183,4 +183,10 @@ bool Configuration::exportConfiguration() const
 std::string Configuration::getSecondTailSource() const
 {
 	return converterFolder + "/log.txt";
+}
+
+void Configuration::clearSecondLog() const
+{
+	std::ofstream clearSecondLog(converterFolder + "/log.txt");
+	clearSecondLog.close();
 }

--- a/Fronter/Source/Configuration/Configuration.h
+++ b/Fronter/Source/Configuration/Configuration.h
@@ -23,6 +23,7 @@ class Configuration: commonItems::parser
 
 	[[nodiscard]] std::string getSecondTailSource() const;
 	[[nodiscard]] bool exportConfiguration() const;
+	void clearSecondLog() const;
 	
   private:
 	void registerKeys();

--- a/Fronter/Source/Frames/LogWindow.cpp
+++ b/Fronter/Source/Frames/LogWindow.cpp
@@ -96,7 +96,6 @@ void LogWindow::OnTailPush(LogMessageEvent& event)
 	}
 
 	const auto message = "  " + logMessage.message;
-
 	theGrid->BeginBatch();
 	theGrid->AppendRows(1, false);
 	theGrid->SetRowSize(logCounter, 20);
@@ -150,4 +149,11 @@ void LogWindow::setLogLevel(int level)
 	GetParent()->Layout();
 	theGrid->Scroll(0, logCounter - 1);
 	theGrid->MakeCellVisible(logCounter - 1, 0);
+}
+
+void LogWindow::blankLog()
+{
+	const auto rows = theGrid->GetNumberRows();
+	theGrid->DeleteRows(0, rows, true);
+	logCounter = 0;	
 }

--- a/Fronter/Source/Frames/LogWindow.h
+++ b/Fronter/Source/Frames/LogWindow.h
@@ -19,6 +19,7 @@ class LogWindow: public wxWindow
 	void terminateSecondTail() const;
 	void OnTailPush(LogMessageEvent& event);
 	void setLogLevel(int level);
+	void blankLog();
 
   private:
 	LogWatcher* logWatcher = nullptr;

--- a/Fronter/Source/Frames/MainFrame.cpp
+++ b/Fronter/Source/Frames/MainFrame.cpp
@@ -14,6 +14,7 @@ MainFrame::MainFrame(const wxString& title, const wxPoint& pos, const wxSize& si
 	Bind(wxEVT_MENU, &MainFrame::OnSupportUs, this, wxID_NETWORK);
 	Bind(wxEVT_PROGRESSMESSAGE, &MainFrame::OnProgressMessage, this);
 	Bind(wxEVT_LOGLEVELCHANGED, &MainFrame::OnLogLevelChange, this);
+	Bind(wxEVT_BLANKLOG, &MainFrame::OnBlankLog, this);
 }
 
 void MainFrame::initFrame()
@@ -104,4 +105,9 @@ void MainFrame::OnProgressMessage(wxCommandEvent& event)
 void MainFrame::OnLogLevelChange(wxCommandEvent& event)
 {
 	logWindow->setLogLevel(event.GetInt());
+}
+
+void MainFrame::OnBlankLog(wxCommandEvent& event)
+{
+	logWindow->blankLog();
 }

--- a/Fronter/Source/Frames/MainFrame.h
+++ b/Fronter/Source/Frames/MainFrame.h
@@ -30,6 +30,7 @@ class MainFrame: public wxFrame
 	void OnSupportUs(wxCommandEvent& event);
 	void OnProgressMessage(wxCommandEvent& event);
 	void OnLogLevelChange(wxCommandEvent& event);
+	void OnBlankLog(wxCommandEvent& event);
 	LogWindow* logWindow = nullptr;
 	wxNotebook* notebook = nullptr;
 	OptionsTab* optionsTab = nullptr;

--- a/Fronter/Source/Frames/Tabs/ConvertTab.h
+++ b/Fronter/Source/Frames/Tabs/ConvertTab.h
@@ -13,6 +13,7 @@
 
 class MainFrame;
 wxDECLARE_EVENT(wxEVT_LOGLEVELCHANGED, wxCommandEvent);
+wxDECLARE_EVENT(wxEVT_BLANKLOG, wxCommandEvent);
 
 class ConvertTab: public wxNotebookPage
 {

--- a/Fronter/Source/Frames/Tabs/PathsTab.cpp
+++ b/Fronter/Source/Frames/Tabs/PathsTab.cpp
@@ -132,13 +132,23 @@ void PathsTab::OnPathChanged(wxFileDirPickerEvent& evt)
 	for (const auto& folder: configuration->getRequiredFolders())
 		if (folder.second->getID() == evt.GetId())
 		{
+			if (!Utils::DoesFolderExist(Utils::UTF16ToUTF8(evt.GetPath().ToStdWstring())))
+			{
+				Log(LogLevel::Error) << "Cannot access folder: " << Utils::UTF16ToUTF8(evt.GetPath().ToStdWstring()) << " - Onedrive and similar symlink folders are not supported!";
+			}
 			std::string result = Utils::UTF16ToUTF8(evt.GetPath().ToStdWstring());
 			folder.second->setValue(result);
+			Log(LogLevel::Info) << folder.second->getName() << " set to: " << Utils::UTF16ToUTF8(evt.GetPath().ToStdWstring());
 		}
 	for (const auto& file: configuration->getRequiredFiles())
 		if (file.second->getID() == evt.GetId())
 		{
+			if (!Utils::DoesFileExist(Utils::UTF16ToUTF8(evt.GetPath().ToStdWstring())))
+			{
+				Log(LogLevel::Error) << "Cannot access file: " << Utils::UTF16ToUTF8(evt.GetPath().ToStdWstring()) << " - Onedrive and similar symlink folders are not supported!";
+			}
 			std::string result = Utils::UTF16ToUTF8(evt.GetPath().ToStdWstring());
 			file.second->setValue(result);
+			Log(LogLevel::Info) << file.second->getName() << " set to: " << Utils::UTF16ToUTF8(evt.GetPath().ToStdWstring());
 		}
 }


### PR DESCRIPTION
- cleaning converter's log.txt between conversions to prevent obsolete data being piped
- cleaning log window between attempts to save on memory
- verifying all paths on selection
- verifying all paths before launching converter
- checking converter exit code and displaying proper message as required
- better syncing of log transcriber and emitter