### PR TITLE
Redefining mandatory

### DIFF
--- a/Fronter/Source/Frames/Tabs/PathsTab.cpp
+++ b/Fronter/Source/Frames/Tabs/PathsTab.cpp
@@ -36,8 +36,6 @@ void PathsTab::initializePaths()
 	}
 	for (const auto& folder: configuration->getRequiredFolders())
 	{
-		if (!folder.second->isMandatory())
-			continue;
 		pickerCounter++;
 		wxStaticText* st = new wxStaticText(this, wxID_ANY, tr(folder.second->getDisplayName()), wxDefaultPosition);
 
@@ -81,8 +79,6 @@ void PathsTab::initializePaths()
 
 	for (const auto& file: configuration->getRequiredFiles())
 	{
-		if (!file.second->isMandatory())
-			continue;
 		pickerCounter++;
 		wxStaticText* st = new wxStaticText(this, wxID_ANY, tr(file.second->getDisplayName()), wxDefaultPosition);
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ searchPathType:
 - direct - copies over an absolute path from searchPath
 
 mandatory:
-- true - will appear in the Paths Tab of the Fronter
+- true - path will be checked and converter won't run without it.
 
 outputtable (relevant for files only):
 - true - will be sent to configuration.txt


### PR DESCRIPTION
- Now all paths appear in fronter, but mandatory ones are checked at output and will block unless verified.
Essentially, mandatory = true now relates to the converter, not the fronter - if converter needs the folder to function, set mandatory to true.