### PR TITLE
Linux and macOS support in UpdateChecker

### DIFF
--- a/Fronter/Source/UpdateChecker/UpdateChecker.cpp
+++ b/Fronter/Source/UpdateChecker/UpdateChecker.cpp
@@ -174,10 +174,10 @@ UpdateInfo getLatestReleaseInfo(const std::string& converterName)
 	auto j = json::parse(jsonResponse);
 	info.description = j["body"];
 	info.version = j["name"];
-	auto assets = j["assets"];
-	for (auto asset : assets)
+	auto& assets = j["assets"];
+	for (auto& asset : assets)
 	{
-		const std::string assetName = asset["name"];
+		std::string assetName = asset["name"];
 #ifdef _WIN32
 		const auto osName = "Windows";
 #elif __linux__
@@ -186,22 +186,20 @@ UpdateInfo getLatestReleaseInfo(const std::string& converterName)
 		const auto osName = "macOS";
 #endif
 
-		const auto expectedAssetName = converterName + "-" + osName + ".zip";
-		std::transform(expectedAssetName.begin(),
-			 expectedAssetName.end(),
-			 expectedAssetName.begin(),
-			 [](unsigned char c)
-			 {
-				 return std::tolower(c);
-			 });
+		auto expectedAssetName = converterName + "-" + osName + ".zip";
+		std::ranges::transform(expectedAssetName,
+		                       expectedAssetName.begin(),
+		                       [](const unsigned char c)
+		                       {
+			                       return std::tolower(c);
+		                       });
 
-		std::transform(assetName.begin(),
-			 assetName.end(),
-			 assetName.begin(),
-			 [](unsigned char c)
-			 {
-				 return std::tolower(c);
-			 });
+		std::ranges::transform(assetName,
+		                       assetName.begin(),
+		                       [](const unsigned char c)
+		                       {
+			                       return std::tolower(c);
+		                       });
 		if (assetName == expectedAssetName)
 		{
 			info.zipURL = asset["browser_download_url"];

--- a/Fronter/Source/UpdateChecker/UpdateChecker.cpp
+++ b/Fronter/Source/UpdateChecker/UpdateChecker.cpp
@@ -179,28 +179,20 @@ UpdateInfo getLatestReleaseInfo(const std::string& converterName)
 	{
 		std::string assetName = asset["name"];
 #ifdef _WIN32
-		const auto osName = "win";
+		const std::string osName = "win";
 #elif __linux__
-		const auto osName = "linux";
+		const std::string osName = "linux";
 #elif __APPLE__
-		const auto osName = "osx";
+		const std::string osName = "osx";
 #endif
-
-		auto expectedAssetName = converterName + "-" + osName + "-x64.zip";
-		std::ranges::transform(expectedAssetName,
-		                       expectedAssetName.begin(),
-		                       [](const unsigned char c)
-		                       {
-			                       return std::tolower(c);
-		                       });
-
+		
 		std::ranges::transform(assetName,
 		                       assetName.begin(),
 		                       [](const unsigned char c)
 		                       {
 			                       return std::tolower(c);
 		                       });
-		if (assetName == expectedAssetName)
+		if (assetName.ends_with("-" + osName + "-x64.zip"))
 		{
 			info.zipURL = asset["browser_download_url"];
 			break;

--- a/Fronter/Source/UpdateChecker/UpdateChecker.cpp
+++ b/Fronter/Source/UpdateChecker/UpdateChecker.cpp
@@ -179,14 +179,14 @@ UpdateInfo getLatestReleaseInfo(const std::string& converterName)
 	{
 		std::string assetName = asset["name"];
 #ifdef _WIN32
-		const auto osName = "Windows";
+		const auto osName = "win";
 #elif __linux__
-		const auto osName = "Linux";
+		const auto osName = "linux";
 #elif __APPLE__
-		const auto osName = "macOS";
+		const auto osName = "osx";
 #endif
 
-		auto expectedAssetName = converterName + "-" + osName + ".zip";
+		auto expectedAssetName = converterName + "-" + osName + "-x64.zip";
 		std::ranges::transform(expectedAssetName,
 		                       expectedAssetName.begin(),
 		                       [](const unsigned char c)

--- a/Fronter/Source/UpdateChecker/UpdateChecker.cpp
+++ b/Fronter/Source/UpdateChecker/UpdateChecker.cpp
@@ -175,14 +175,22 @@ UpdateInfo getLatestReleaseInfo(const std::string& converterName)
 	for (auto asset : assets)
 	{
 		const std::string assetName = asset["name"];
-		if (assetName.ends_with(".zip"))
+#ifdef _WIN32
+		const auto osName = "Windows";
+#elif __linux__
+		const auto osName = "Linux";
+#elif __APPLE__
+		const auto osName = "macOS";
+#endif
+		if (assetName == converterName + "-" + osName + ".zip")
 		{
 			info.zipURL = asset["browser_download_url"];
+			break;
 		}
 	}
 	if (!info.zipURL)
 	{
-		Log(LogLevel::Warning) << "Release " << info.version << " has no .zip asset.";
+		Log(LogLevel::Warning) << "Release " << info.version << " doesn't have a .zip asset.";
 	}
 	return info;
 }

--- a/Fronter/Source/UpdateChecker/UpdateChecker.cpp
+++ b/Fronter/Source/UpdateChecker/UpdateChecker.cpp
@@ -1,8 +1,11 @@
 #include "UpdateChecker.h"
 #include "OSCompatibilityLayer.h"
 #include "ParserHelpers.h"
-#include <fstream>
+#include <algorithm>
+#include <cctype>
 #include <codecvt>
+#include <fstream>
+#include <string>
 #include <curl/curl.h>
 #include <nlohmann/json.hpp>
 #include <wx/utils.h>
@@ -182,7 +185,24 @@ UpdateInfo getLatestReleaseInfo(const std::string& converterName)
 #elif __APPLE__
 		const auto osName = "macOS";
 #endif
-		if (assetName == converterName + "-" + osName + ".zip")
+
+		const auto expectedAssetName = converterName + "-" + osName + ".zip";
+		std::transform(expectedAssetName.begin(),
+			 expectedAssetName.end(),
+			 expectedAssetName.begin(),
+			 [](unsigned char c)
+			 {
+				 return std::tolower(c);
+			 });
+
+		std::transform(assetName.begin(),
+			 assetName.end(),
+			 assetName.begin(),
+			 [](unsigned char c)
+			 {
+				 return std::tolower(c);
+			 });
+		if (assetName == expectedAssetName)
 		{
 			info.zipURL = asset["browser_download_url"];
 			break;


### PR DESCRIPTION
From now on, release archive names will need to end with `-<os name>-x64.zip` in order to be detected by UpdateChecker,
where `os name` is `win`, `linux` or `osx`.