### PR TITLE
Read backend exe path from fronter-configuration.txt

### DIFF
--- a/Fronter/Source/Configuration/Configuration.cpp
+++ b/Fronter/Source/Configuration/Configuration.cpp
@@ -104,8 +104,10 @@ void Configuration::registerKeys()
 		name = nameStr.getString();
 	});
 	registerKeyword("converterFolder", [this](std::istream& theStream) {
-		const commonItems::singleString nameStr(theStream);
-		converterFolder = nameStr.getString();
+		converterFolder = commonItems::getString(theStream);
+	});
+	registerKeyword("backendExePath", [this](std::istream& theStream) {
+		backendExePath = commonItems::getString(theStream);
 	});
 	registerKeyword("requiredFolder", [this](std::istream& theStream) {
 		auto newFolder = std::make_shared<RequiredFolder>(theStream);

--- a/Fronter/Source/Configuration/Configuration.h
+++ b/Fronter/Source/Configuration/Configuration.h
@@ -1,6 +1,5 @@
 #ifndef CONFIGURATION
 #define CONFIGURATION
-#include "Log.h"
 #include "Mod.h"
 #include "Options/Option.h"
 #include "Parser.h"
@@ -28,6 +27,7 @@ class Configuration: commonItems::parser
 	[[nodiscard]] const auto& getRequiredFiles() const { return requiredFiles; }
 	[[nodiscard]] const auto& getRequiredFolders() const { return requiredFolders; }
 	[[nodiscard]] const auto& getConverterFolder() const { return converterFolder; }
+	[[nodiscard]] const auto& getBackendExePath() const { return backendExePath; }
 	[[nodiscard]] const auto& getOptions() const { return options; }
 
 	[[nodiscard]] std::string getSecondTailSource() const;
@@ -43,6 +43,7 @@ class Configuration: commonItems::parser
 
 	std::string name;
 	std::string converterFolder;
+	std::string backendExePath; // relative to converterFolder
 	std::string displayName;
 	std::string sourceGame;
 	std::string targetGame;

--- a/Fronter/Source/WorkerThreads/ConverterLauncher/LinuxConverterLauncher.cpp
+++ b/Fronter/Source/WorkerThreads/ConverterLauncher/LinuxConverterLauncher.cpp
@@ -1,3 +1,4 @@
+#include "CommonFunctions.h"
 #include "ConverterLauncher.h"
 #include "Log.h"
 #include "OSCompatibilityLayer.h"

--- a/Fronter/Source/WorkerThreads/ConverterLauncher/LinuxConverterLauncher.cpp
+++ b/Fronter/Source/WorkerThreads/ConverterLauncher/LinuxConverterLauncher.cpp
@@ -22,7 +22,7 @@ void* ConverterLauncher::Entry()
 		m_pParent->AddPendingEvent(evt);
 		return nullptr;
 	}
-	if (!commonItems::DoesFileExist(backendExePathRelativeToFrontend.string()))
+	if (!commonItems::DoesFileExist(backendExePathString))
 	{
 		Log(LogLevel::Error) << "Could not find converter executable!";
 		evt.SetInt(0);
@@ -30,10 +30,11 @@ void* ConverterLauncher::Entry()
 		return nullptr;
 	}
 
+	const auto backendExeName = trimPath(backendExePathString);
 	const auto workDir = getPath(backendExePathString);
 	const auto stopWatchStart = std::chrono::steady_clock::now();
 
-	auto exeCommand = "cd " + workDir + "; " + converterExe;
+	auto exeCommand = "cd " + workDir + "; " + backendExeName;
 	const char* exeCommandChar = exeCommand.c_str();
 
 	auto result = system(exeCommandChar);

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ but Fronter will whine if it can't find either. It's better to have them separat
 ```
 name = CK2ToEU4
 converterFolder = CK2ToEU4
+backendExePath = CK2ToEU4Converter # Relative to converterFolder. If file extension is "exe", skip it.
 displayName = DISPLAYNAME
 sourceGame = SOURCEGAME
 targetGame = TARGETGAME
@@ -34,18 +35,6 @@ requiredFile = {
 	searchPathType = windowsUsersFolder
 	searchPath = "Paradox Interactive\Crusader Kings II\save games"
 	allowedExtension = "*.ck2"
-}
-
-requiredFile = {
-	name = converterExe
-	displayName = FILE1
-	tooltip = FILE1TIP
-	mandatory = true
-	outputtable = false
-	searchPathType = converterFolder
-	searchPath = "CK2ToEU4"
-	allowedExtension = "*.exe"
-	fileName = "CK2ToEU4Converter.exe"
 }
 
 requiredFolder = {
@@ -72,7 +61,7 @@ autoGenerateModsFrom:
 
 searchPathType:
 -   converterFolder - looks in the provided converterFolder in current directory
--   steamFolder - uses searchPathID to look for an "installation path" from windows/steam registry. If there's a match it will also append searchPath at the end so you can use this for Vic2installdir/mods.
+-   steamFolder - uses searchPathID to look for an "installation path" from Windows/Steam registry. If there's a match it will also append searchPath at the end so you can use this for Vic2installdir/mods.
 -   windowsUsersFolder - looks in $USERHOMEDIR$\Documents folder
 -   direct - copies over an absolute path from searchPath
 


### PR DESCRIPTION
See the changes in README.md for required converter side changes.
The advantage is one less input a user can fill with shit.
![image](https://user-images.githubusercontent.com/29546927/148659941-9a314bb7-6588-4d2c-974b-8f6844cf5b6c.png)

Marking as draft since this is a breaking change.